### PR TITLE
get build up, tests running and passing

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -79,8 +79,8 @@ module.exports = (grunt) ->
     # -----------------
     urequire:
       AMD:
-        bundlePath: 'temp/'
-        outputPath: 'temp/'
+        path: 'src/'
+        dstPath: 'temp/'
 
         options:
           forceOverwriteSources: true
@@ -139,7 +139,7 @@ module.exports = (grunt) ->
               author: 'Chaplin team',
               license: 'MIT',
               bugs: { url: 'https://github.com/chaplinjs/downloads/issues' },
-              dependencies: { backbone: '~1.1.2', underscore: '~1.6.0' }
+              dependencies: { backbone: '~1.1.2', underscore: '~1.6.0', requirejs: '2.1.1' }
             }
           }
         ]

--- a/src/chaplin/dispatcher.coffee
+++ b/src/chaplin/dispatcher.coffee
@@ -2,6 +2,7 @@
 
 _ = require 'underscore'
 Backbone = require 'backbone'
+requirejs = require 'require'
 mediator = require 'chaplin/mediator'
 utils = require 'chaplin/lib/utils'
 EventBroker = require 'chaplin/lib/event_broker'
@@ -80,10 +81,10 @@ module.exports = class Dispatcher
     fileName = name + @settings.controllerSuffix
     moduleName = @settings.controllerPath + fileName
     if define?.amd
-      require [moduleName], handler
+      requirejs [moduleName], handler
     else
       setTimeout =>
-        handler require moduleName
+        handler requirejs(moduleName)
       , 0
 
   # Handler for the controller lazy-loading.


### PR DESCRIPTION
`urequire` looks for every call to `require` and then statically compiles that file... This doesn't work for async requiring, which happens in `Dispatcher#loadController`. To get around this, we have to `require` `require` and set it to a different variable so it doesn't get `require`'d at compile time.

Yo dawg, I hear...

Interesting reading if you care:
http://urequire.org/frequently-asked-questions
https://github.com/jrburke/requirejs/wiki/Upgrading-to-RequireJS-2.1#breaking-async
