### PR TITLE
safely call to `@$` after disposal

### DIFF
--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -180,6 +180,17 @@ module.exports = class View extends Backbone.View
     # Render automatically if set by options or instance property.
     @render() if @autoRender
 
+  # Override `Backbone.$`
+  # -------------------------
+
+  # This makes it safer for views to call `@$` after disposal,
+  # which happens fairly often when dealing with async callbacks.
+  $: ->
+    if @disposed
+     return $()
+    else
+      return super
+
   # User input event handling
   # -------------------------
 


### PR DESCRIPTION
Return an empty jQuery object when when calling $ on an already disposed view. This makes all async funcs called after disposal not break.
